### PR TITLE
modify the my_etruncnorm and my_vtruncnorm function

### DIFF
--- a/R/truncnorm.R
+++ b/R/truncnorm.R
@@ -19,33 +19,23 @@ my_etruncnorm= function(a,b,mean=0,sd=1){
   #Fix a bug of quoting the truncnorm package
   #E(X|a<X<b)=a when a==b is a natural result
   #while etruncnorm would simply return NaN,causing PosteriorMean also NaN
-#   tmp1=etruncnorm(alpha,beta,0,1)
-#   isequal=is.equal(alpha,beta)
-#   
-#   tmp1[isequal]=alpha[isequal]
-#   
-#   tmp= (-1)^flip * (mean+sd*tmp1)
-#   
-#   max_alphabeta = ifelse(alpha<beta, beta,alpha)
-#   max_ab = ifelse(alpha<beta,b,a)
-#   toobig = max_alphabeta<(-30)
-#   toobig[is.na(toobig)]=FALSE
-#   tmp[toobig] = max_ab[toobig]
   # ZMZ:  when a and b are both negative and far from 0, etruncnorm can't compute
-  # the mean and variance
-  tmp1=ifelse(!flip,etruncnorm(alpha,beta,0,1),etruncnorm(beta,alpha,0,1))
+  # the mean and variance. Also we should deal with 0/0 situation caused by sd = 0.
+  tmp1=etruncnorm(alpha,beta,0,1)
   isequal=is.equal(alpha,beta)
-  tmp1[isequal]=alpha[isequal]*(-1)^flip[isequal]
-  not = is.na(tmp1)
-  #tmp1[not] = max(beta[not],alpha[not])
-  tmp1[not] = apply(cbind(beta[not],alpha[not]),1,max)
-  tmp=as.matrix(mean+sd*tmp1)
+  
+  tmp1[isequal]=beta[isequal]
+  
+  tmp= (-1)^flip * (mean+sd*tmp1)
   
   max_alphabeta = ifelse(alpha<beta, beta,alpha)
   max_ab = ifelse(alpha<beta,b,a)
   toobig = max_alphabeta<(-30)
   toobig[is.na(toobig)]=FALSE
   tmp[toobig] = max_ab[toobig]
+
+  sdzero = sd == 0
+  tmp[sdzero] = mean[sdzero]
   tmp
 }
 

--- a/R/truncnorm.R
+++ b/R/truncnorm.R
@@ -24,7 +24,7 @@ my_etruncnorm= function(a,b,mean=0,sd=1){
   tmp1=etruncnorm(alpha,beta,0,1)
   isequal=is.equal(alpha,beta)
   
-  tmp1[isequal]=beta[isequal]
+  tmp1[isequal]=alpha[isequal]
   
   tmp= (-1)^flip * (mean+sd*tmp1)
   
@@ -35,7 +35,15 @@ my_etruncnorm= function(a,b,mean=0,sd=1){
   tmp[toobig] = max_ab[toobig]
 
   sdzero = sd == 0
-  tmp[sdzero] = mean[sdzero]
+  if(a[sdzero]<=mean[sdzero] & b[sdzero]>=mean[sdzero]){
+    tmp[sdzero] = mean[sdzero]
+  }
+  else if(a[sdzero] > mean[sdzero]){
+    tmp[sdzero] = a[sdzero]
+  }
+  else{
+    tmp[sdzero] = b[sdzero]
+  }
   tmp
 }
 

--- a/R/truncnorm.R
+++ b/R/truncnorm.R
@@ -35,6 +35,7 @@ my_etruncnorm= function(a,b,mean=0,sd=1){
   tmp[toobig] = max_ab[toobig]
 
   sdzero = sd == 0
+  if(sum(sdzero) > 0) {
   if(a[sdzero]<=mean[sdzero] & b[sdzero]>=mean[sdzero]){
     tmp[sdzero] = mean[sdzero]
   }
@@ -44,6 +45,8 @@ my_etruncnorm= function(a,b,mean=0,sd=1){
   else{
     tmp[sdzero] = b[sdzero]
   }
+  }
+  
   tmp
 }
 

--- a/R/truncnorm.R
+++ b/R/truncnorm.R
@@ -114,12 +114,10 @@ my_vtruncnorm = function(a,b,mean = 0, sd = 1){
   beta =  (b-mean)/sd
   frac1 = (beta*stats::dnorm(beta,0,1) - alpha*stats::dnorm(alpha,0,1)) / (stats::pnorm(beta,0,1)-stats::pnorm(alpha,0,1) )
   frac2 = (stats::dnorm(beta,0,1) - stats::dnorm(alpha,0,1)) / (stats::pnorm(beta,0,1)-stats::pnorm(alpha,0,1) )
-  # ZMZ: deal with NAs when both the numerator and denominator is zero
-  # not = is.na(frac1)
-  # frac1[not]=
   truncnormvar = sd^2 * (1 - frac1 - frac2^2)
+  
   # turn all nan and negative into 0
-  not = is.na(truncnormvar) | truncnormvar < 0
-  truncnormvar[not] = 0
+  nan.index = is.na(truncnormvar) | truncnormvar < 0
+  truncnormvar[nan.index] = 0
   return(truncnormvar)
 }

--- a/tests/testthat/test_myetruncnorm.R
+++ b/tests/testthat/test_myetruncnorm.R
@@ -1,0 +1,5 @@
+test_that("some test about my_etrucnorm function", {
+  expect_equal(-100,my_etruncnorm(-Inf,-100,0,1),tolerance=0.01)
+  expect_equal(-100,my_etruncnorm(-Inf,-100,0,0))
+  expect_equal(30,my_etruncnorm(30,100,0,0))
+})


### PR DESCRIPTION
my_etruncnorm:

Original version only consider the NA case when a==b. And make expectation equals to a. Actually etruncnorm will generate NA under three conditions: a==b; a=-Inf, b=-1000; a=0 or b=0, mean=sd=0.

for example, when a=-Inf, b=-1000, mean=0, sd=1. 
(originally) my_etruncnorm(a,b,mean,sd) = -Inf
(in fact) my_etruncnorm(a,b,mean,sd) = -1000

when a = 0, b = Inf, mean=0, sd=0
(originally) my_ectruncnorm(a,b,mean,sd) = NA
(actually) my_ectruncnorm(a,b,mean,sd) = 0

Also in my_vtruncnorm function there is some problem. When both a and b are negatively far from 0. There will be 0/0 case and generate Nan. While g is mixture truncated normal, such phenomenon is common.

For example, when a=-10000, b=-9999, mean=0,sd=1.
(originally) my_vtruncnorm(a,b,mean,sd) = Nan
(in fact) we should replace it with 0.
