### PR TITLE
Windows CI and Code Coverage

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^appveyor\.yml$
+^codecov\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
 ^\.travis\.yml$
-^\.travis\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^appveyor\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,5 @@ r_github_packages:
   - jimhester/covr
 
 after_success:
+  - Rscript -e 'covr::coveralls()'
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - ./travis-tool.sh install_deps
   - ./travis-tool.sh install_github
-  
+
 script: ./travis-tool.sh run_tests
 
 on_failure:
@@ -20,7 +20,7 @@ notifications:
   email:
     on_success: change
     on_failure: change
-    
+
 sudo: required
 
 env:
@@ -33,3 +33,9 @@ env:
 branches:
   only:
     - master
+
+r_github_packages:
+  - jimhester/covr
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ LinkingTo: Rcpp
 Suggests:
     REBayes,
     testthat,
-    roxygen2
+    roxygen2,
+    covr
 URL: "http://github.com/stephens999/ashr
 RoxygenNote: 5.0.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/stephens999/ashr.svg)](https://travis-ci.org/stephens999/ashr)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/dcgerard/ashr?branch=master&svg=true)](https://ci.appveyor.com/project/dcgerard/ashr)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/stephens999/ashr?branch=master&svg=true)](https://ci.appveyor.com/project/stephens999/ashr)
+[![Coverage Status](https://coveralls.io/repos/github/stephens999/ashr/badge.svg?branch=master)](https://coveralls.io/github/stephens999/ashr?branch=master)
 
 This repository contains an R package for performing "Adaptive Shrinkage."
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/stephens999/ashr.svg)](https://travis-ci.org/stephens999/ashr)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/dcgerard/ashr?branch=master&svg=true)](https://ci.appveyor.com/project/dcgerard/ashr)
 
 This repository contains an R package for performing "Adaptive Shrinkage."
 
@@ -19,7 +20,7 @@ The main function in the ashr package is `ash`. To get minimal help:
 
 ## More background
 
-The ashr (``Adaptive SHrinkage") package aims to provide simple, generic, and flexible methods to derive ``shrinkage-based" estimates and credible intervals for unknown quantities $\beta=(\beta_1,\dots,\beta_J)$, given only estimates of those quantities ($\hat\beta=(\hat\beta_1,\dots, \hat\beta_J)$) and their corresponding estimated standard errors ($s=(s_1,\dots,s_J)$). 
+The ashr (``Adaptive SHrinkage") package aims to provide simple, generic, and flexible methods to derive ``shrinkage-based" estimates and credible intervals for unknown quantities $\beta=(\beta_1,\dots,\beta_J)$, given only estimates of those quantities ($\hat\beta=(\hat\beta_1,\dots, \hat\beta_J)$) and their corresponding estimated standard errors ($s=(s_1,\dots,s_J)$).
 
 The ``adaptive" nature of the shrinkage is two-fold. First, the appropriate amount of shrinkage is determined from the data, rather than being pre-specified. Second, the amount of shrinkage undergone by each $\hat\beta_j$ will depend on the standard error $s_j$: measurements with high standard error will undergo more shrinkage than measurements with low standard error.
 
@@ -30,7 +31,7 @@ The methods are based on treating the vectors $\hat\beta$
 and $s$ as ``observed data", and then performing inference for $\beta$ from these observed data, using a standard hierarchical modelling framework
 to combine information across $j=1,\dots,J$.
 
-Specifically, we assume that the true 
+Specifically, we assume that the true
 $\beta_j$ values are independent
 and identically distributed from some unimodal distribution $g$.
 By default we assume $g$ is unimodal about zero and symmetric.
@@ -41,4 +42,3 @@ Then, we assume that the observations $\hat\beta_j \sim N(\beta_j,s_j)$,
 or alternatively the normal assumption can be replaced by a $t$ distribution
 by specifying `df`, the number of degrees of freedom used to estimate $s_j$.
 Actually this is important: do be sure to specify `df` if you can.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/stephens999/ashr.svg)](https://travis-ci.org/stephens999/ashr)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/stephens999/ashr?branch=master&svg=true)](https://ci.appveyor.com/project/stephens999/ashr)
 [![Coverage Status](https://coveralls.io/repos/github/stephens999/ashr/badge.svg?branch=master)](https://coveralls.io/github/stephens999/ashr?branch=master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/stephens999/ashr/master.svg)](https://codecov.io/github/stephens999/ashr?branch=master)
 
 This repository contains an R package for performing "Adaptive Shrinkage."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    - _R_CHECK_FORCE_SUGGESTS_: false
+    R_CHECK_ARGS: '_R_CHECK_FORCE_SUGGESTS_ = FALSE'
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ install:
 
 # Adapt as necessary starting from here
 environment:
-  - _R_CHECK_FORCE_SUGGESTS_=false
+  global:
+    - _R_CHECK_FORCE_SUGGESTS_: false
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,6 @@ install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
-environment:
-  global:
-    - CRAN=http://cran.rstudio.com
-    - NOT_CRAN=true
-    - _R_CHECK_CRAN_INCOMING_=false
-    - _R_CHECK_FORCE_SUGGESTS_=false
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    R_CHECK_ARGS: '_R_CHECK_FORCE_SUGGESTS_=false NOT_CRAN=true'
+    _R_CHECK_FORCE_SUGGESTS_: false
+    NOT_CRAN: true
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,12 @@ install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
-env:
+environment:
   global:
-    - NOT_CRAN: true
-    - _R_CHECK_CRAN_INCOMING_: false
-    - _R_CHECK_FORCE_SUGGESTS_: false
+    - CRAN=http://cran.rstudio.com
+    - NOT_CRAN=true
+    - _R_CHECK_CRAN_INCOMING_=false
+    - _R_CHECK_FORCE_SUGGESTS_=false
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,10 @@ install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
+environment:
+  global:
+    - _R_CHECK_FORCE_SUGGESTS_=false
+
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    _R_CHECK_FORCE_SUGGESTS_: false
     NOT_CRAN: true
+    _R_CHECK_FORCE_SUGGESTS_: false
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ install:
 
 # Adapt as necessary starting from here
 environment:
-  global:
   - _R_CHECK_FORCE_SUGGESTS_=false
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    - _R_CHECK_FORCE_SUGGESTS_=false
+  - _R_CHECK_FORCE_SUGGESTS_=false
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,9 @@ install:
 # Adapt as necessary starting from here
 env:
   global:
-    - CRAN=http://cran.rstudio.com
-    - NOT_CRAN=true
-    - _R_CHECK_CRAN_INCOMING_=false
-    - _R_CHECK_FORCE_SUGGESTS_=false
+    - NOT_CRAN: true
+    - _R_CHECK_CRAN_INCOMING_: false
+    - _R_CHECK_FORCE_SUGGESTS_: false
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,7 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    NOT_CRAN=true
-    _R_CHECK_FORCE_SUGGESTS_=false
+    R_CHECK_ARGS: '_R_CHECK_FORCE_SUGGESTS_=false NOT_CRAN=true'
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,12 @@ install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
+env:
+  global:
+    - CRAN=http://cran.rstudio.com
+    - NOT_CRAN=true
+    - _R_CHECK_CRAN_INCOMING_=false
+    - _R_CHECK_FORCE_SUGGESTS_=false
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ install:
 # Adapt as necessary starting from here
 environment:
   global:
-    R_CHECK_ARGS: '_R_CHECK_FORCE_SUGGESTS_ = FALSE'
+    NOT_CRAN=true
+    _R_CHECK_FORCE_SUGGESTS_=false
 
 
 build_script:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
I set up AppVeyor, Codecov, and Coveralls for ashr.

AppVeyor is Travis for Windows.

Codecov and Coveralls measure your code's unit testing coverage.

I made the badges in README.md so that they will point to the stephens999 repo.

You'll have to sign up for coveralls, codecov, and appveyor, but this is free and easy. For appveyor and coveralls, you'll have to tell them that you want them to look at the ashr repo. For codecov, the ashr repo will be analyzed automatically.

Turn on coveralls: https://coveralls.io/repos/new
Turn on appveyor: https://ci.appveyor.com/projects

Results from my fork:
https://ci.appveyor.com/project/dcgerard/ashr
https://codecov.io/gh/dcgerard/ashr
https://coveralls.io/github/dcgerard/ashr