### PR TITLE
test for df = Inf, then switch to df = NULL

### DIFF
--- a/R/ash.R
+++ b/R/ash.R
@@ -107,7 +107,7 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #'     betahat/sebetahat, default is NULL(Gaussian)
 #' @param nullweight scalar, the weight put on the prior under
 #'     "nullbiased" specification, see \code{prior}
-#' @param mode either numeric (indicating mode of g) or string "estimate", 
+#' @param mode either numeric (indicating mode of g) or string "estimate",
 #'      to indicate mode should be estimated.
 #' @param pointmass logical, indicating whether to use a point mass at
 #'     zero as one of components for a mixture distribution
@@ -124,7 +124,7 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #'     1=also PosteriorMean and PosteriorSD; 2= everything usually
 #'     needed; 3=also include results of mixture fitting procedure
 #'     (includes matrix of log-likelihoods used to fit mixture); 4=
-#'     output additional things required by flash (flash_data)]. Otherwise the user can also specify 
+#'     output additional things required by flash (flash_data)]. Otherwise the user can also specify
 #'     the output they require in detail (see Examples)
 #' @param g the prior distribution for beta (usually estimated from
 #'     the data; this is used primarily in simulated data to do
@@ -134,7 +134,7 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #' @param alpha numeric value of alpha parameter in the model
 #' @param control A list of control parameters passed to optmethod
 #' @param lik contains details of the likelihood used; for general ash
-#' 
+#'
 #' @return ash returns an object of \code{\link[base]{class}} "ash", a list with some or all of the following elements (determined by outputlevel) \cr
 #' \item{fitted_g}{fitted mixture, either a normalmix or unimix}
 #' \item{loglik}{log P(D|mle(pi))}
@@ -168,7 +168,7 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #' head(beta.ash$result) #dataframe of results
 #' head(get_lfsr(beta.ash)) #get lfsr
 #' head(get_pm(beta.ash)) #get posterior mean
-#' graphics::plot(betahat,get_pm(beta.ash),xlim=c(-4,4),ylim=c(-4,4)) 
+#' graphics::plot(betahat,get_pm(beta.ash),xlim=c(-4,4),ylim=c(-4,4))
 #'
 #' CIMatrix=ashci(beta.ash,level=0.95) #note currently default is only compute CIs for lfsr<0.05
 #' print(CIMatrix)
@@ -176,14 +176,14 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #' #Running ash with different error models
 #' beta.ash1 = ash(betahat, sebetahat, lik = normal_lik())
 #' beta.ash2 = ash(betahat, sebetahat, lik = t_lik(df=4))
-#' 
+#'
 #' e = rnorm(100)+log(rf(100,df1=10,df2=10)) # simulated data with log(F) error
-#' e.ash = ash(e,1,lik=logF_lik(df1=10,df2=10)) 
-#' 
-#' 
+#' e.ash = ash(e,1,lik=logF_lik(df1=10,df2=10))
+#'
+#'
 #' # Specifying the output
 #' beta.ash = ash(betahat, sebetahat, output = c("fitted_g","logLR","lfsr"))
-#' 
+#'
 #' #Illustrating the non-zero mode feature
 #' betahat=betahat+5
 #' beta.ash = ash(betahat, sebetahat)
@@ -191,7 +191,7 @@ ash = function(betahat,sebetahat,mixcompdist = c("uniform","halfuniform","normal
 #' betan.ash=ash(betahat, sebetahat,mode=5)
 #' graphics::plot(betahat, betan.ash$result$PosteriorMean)
 #' summary(betan.ash)
-#' 
+#'
 #'
 #' #Running ash with a pre-specified g, rather than estimating it
 #' beta = c(rep(0,100),rnorm(100))
@@ -219,7 +219,7 @@ ash.workhorse = function(betahat,sebetahat,
                          control=list(),
                          lik=NULL
 ){
-  
+
   if(!missing(pointmass) & !missing(method))
     stop("Specify either method or pointmass, not both")
   if(!missing(prior) & !missing(method))
@@ -231,7 +231,14 @@ ash.workhorse = function(betahat,sebetahat,
     if (method == "shrink"){pointmass =FALSE; prior="uniform"}
     if (method == "fdr"){pointmass =TRUE; prior= "nullbiased"}
   }
-  
+
+  ## Check to see if is Inf, then switch to NULL.
+  if (!is.null(df)) {
+    if (df == Inf) {
+      df <- NULL
+    }
+  }
+
   if(mode=="estimate"){ #just pass everything through to ash.estmode for non-zero-mode
     args <- as.list(environment())
     args$mode = NULL
@@ -240,15 +247,15 @@ ash.workhorse = function(betahat,sebetahat,
     args$g = NULL # avoid specifying g as well as mode
     #args = as.list( match.call() )
     mode = do.call(ash.estmode,args)}
-  
-  
+
+
   ##1.Handling Input Parameters
   mixcompdist = match.arg(mixcompdist)
   optmethod   = match.arg(optmethod)
   prior       = match.arg(prior)
- 
+
   # Set optimization method
-  optmethod = set_optmethod(optmethod)  
+  optmethod = set_optmethod(optmethod)
   check_args(mixcompdist,df,prior,optmethod,gridmult,sebetahat,betahat)
   if(is.null(lik)){ #set likelihood based on defaults if missing
     if(is.null(df)){
@@ -258,14 +265,14 @@ ash.workhorse = function(betahat,sebetahat,
   check_lik(lik) # minimal check that it obeys requirements
   lik = add_etruncFUN(lik) #if missing, add a function to compute mean of truncated distribution
   data = set_data(betahat, sebetahat, lik, alpha)
-  
+
   ##2. Generating mixture distribution g
 
   if(fixg & missing(g)){stop("if fixg=TRUE then you must specify g!")}
 
   if(!is.null(g)){
     k=ncomp(g)
-    null.comp=1 #null.comp not actually used 
+    null.comp=1 #null.comp not actually used
     prior = setprior(prior,k,nullweight,null.comp)
   } else {
     if(is.null(mixsd)){
@@ -279,8 +286,8 @@ ash.workhorse = function(betahat,sebetahat,
     k = length(mixsd)
     prior = setprior(prior,k,nullweight,null.comp)
     pi = initpi(k,length(data$x),null.comp)
-    
-    if(!is.element(mixcompdist,c("normal","uniform","halfuniform","+uniform","-uniform"))) 
+
+    if(!is.element(mixcompdist,c("normal","uniform","halfuniform","+uniform","-uniform")))
       stop("Error: invalid type of mixcompdist")
     if(mixcompdist=="normal") g=normalmix(pi,rep(mode,k),mixsd)
     if(mixcompdist=="uniform") g=unimix(pi,mode - mixsd,mode + mixsd)
@@ -323,7 +330,7 @@ ash.workhorse = function(betahat,sebetahat,
   if("fit_details" %in% output){val = c(val,list(fit_details = pi.fit))}
   if("flash_data" %in% output){val = c(val, list(flash_data=calc_flash_data(ghat,data)))}
 
-  # Compute the result component of value - 
+  # Compute the result component of value -
   # result is a dataframe containing lfsr, etc
   # resfns is a list of functions used to produce columns of that dataframe
   resfns = set_resfns(output)
@@ -332,7 +339,7 @@ ash.workhorse = function(betahat,sebetahat,
     if(!is.null(df)){result$df = df}
     result = cbind(result,as.data.frame(lapply(resfns,do.call,list(g=pi.fit$g,data=data))))
     val = c(val, list(result=result))
-  } 
+  }
 
   ##5. Returning the val
 
@@ -403,22 +410,22 @@ gradient = function(matrix_lik){
 }
 
 #' Estimate mixture proportions of a mixture g given noisy (error-prone) data from that mixture.
-#' 
+#'
 #' @details This is used by the ash function. Most users won't need to call this directly, but is
 #' exported for use by some other related packages.
 #'
 #' @param data list to be passed to log_comp_dens_conv; details depend on model
 #' @param g an object representing a mixture distribution (eg normalmix for mixture of normals;
 #'  unimix for mixture of uniforms). The component parameters of g (eg the means and variances) specify the
-#'  components whose mixture proportions are to be estimated. The mixture proportions of g are the parameters to be estimated; 
-#'  the values passed in may be used to initialize the optimization (depending on the optmethod used) 
-#' @param prior numeric vector indicating parameters of "Dirichlet prior" 
-#'     on mixture proportions 
+#'  components whose mixture proportions are to be estimated. The mixture proportions of g are the parameters to be estimated;
+#'  the values passed in may be used to initialize the optimization (depending on the optmethod used)
+#' @param prior numeric vector indicating parameters of "Dirichlet prior"
+#'     on mixture proportions
 #' @param optmethod name of function to use to do optimization
-#' @param control list of control parameters to be passed to optmethod, 
+#' @param control list of control parameters to be passed to optmethod,
 #' typically affecting things like convergence tolerance
-#' @return list, including the final loglikelihood, the null loglikelihood, 
-#' an n by k likelihood matrix with (j,k)th element equal to \eqn{f_k(x_j)}, 
+#' @return list, including the final loglikelihood, the null loglikelihood,
+#' an n by k likelihood matrix with (j,k)th element equal to \eqn{f_k(x_j)},
 #' the fit
 #' and results of optmethod
 #' @export
@@ -428,7 +435,7 @@ estimate_mixprop = function(data,g,prior,optmethod=c("mixEM","mixVBEM","cxxMixSq
   pi_init = g$pi
   if(optmethod=="mixVBEM"){pi_init=NULL}  #for some reason pi_init doesn't work with mixVBEM
   k=ncomp(g)
-  
+
   matrix_llik = t(log_comp_dens_conv(g,data)) #an n by k matrix
   matrix_llik = matrix_llik[!get_exclusions(data),] #remove any rows corresponding to excluded cases; saves time in situations where most data are missing
   matrix_llik = matrix_llik - apply(matrix_llik,1, max) #avoid numerical issues by subtracting max of each row
@@ -581,7 +588,7 @@ autoselect.mixsd = function(data,mult,mode){
   exclude = get_exclusions(data)
   betahat = betahat[!exclude]
   sebetahat = sebetahat[!exclude]
-  
+
   sigmaamin = min(sebetahat)/10 #so that the minimum is small compared with measurement precision
   if(all(betahat^2<=sebetahat^2)){
     sigmaamax = 8*sigmaamin #to deal with the occassional odd case where this could happen; 8 is arbitrary

--- a/tests/testthat/test_df.R
+++ b/tests/testthat/test_df.R
@@ -1,0 +1,11 @@
+test_that("df switches", {
+    betahat <- c(1.01636974224394, -2.05686254738995, -0.7135781676358,
+                 -1.16906745227838, -0.917039991627176)
+
+    sebetahat <- c(1.02572223086898, 0.499285201440522, 0.476520330150983,
+                   0.624576594477857, 0.198152636610839)
+
+    aout <- ash.workhorse(betahat = betahat[1:5], sebetahat = sebetahat[1:5], df = Inf)
+    expect_true(all(!is.nan(aout$result$PosteriorMean)))
+}
+)


### PR DESCRIPTION
PosteriorMean and PosteriorSD have `NaN`'s when `df = Inf`
================

Example Code
============

Create example data.

``` r
betahat <- c(1.01636974224394, -2.05686254738995, -0.7135781676358,
             -1.16906745227838, -0.917039991627176)

sebetahat <- c(1.02572223086898, 0.499285201440522, 0.476520330150983,
               0.624576594477857, 0.198152636610839)
```

Fit `ash` with `df = Inf`.

``` r
aout <- ashr::ash.workhorse(betahat = betahat[1:5],
                            sebetahat = sebetahat[1:5], df = Inf)
aout$result$PosteriorMean
```

    ## [1] NaN NaN NaN NaN NaN

``` r
aout$result$PosteriorSD
```

    ## [1] NaN NaN NaN NaN NaN

Fit `ash` with large `df`.

``` r
aout <- ashr::ash.workhorse(betahat = betahat[1:5],
                            sebetahat = sebetahat[1:5], df = 10000)
aout$result$PosteriorMean
```

    ## [1]  0.1211 -1.6425 -0.1231 -0.3406 -0.9163

``` r
aout$result$PosteriorSD
```

    ## [1] 0.4258 0.3486 0.3324 0.5809 0.1998

Fit ash with `df = NULL`.

``` r
aout <- ashr::ash.workhorse(betahat = betahat[1:5],
                            sebetahat = sebetahat[1:5], df = NULL)
aout$result$PosteriorMean
```

    ## [1]  0.1211 -1.6426 -0.1231 -0.3406 -0.9163

``` r
aout$result$PosteriorSD
```

    ## [1] 0.4258 0.3485 0.3324 0.5809 0.1997

Fix
===

I just added a check in `ash.workhorse` for whether `df == Inf`, then set `df = NULL` if `TRUE`.

The rest of the lines that are "modified" are just because my Emacs auto-deletes superfluous white-space when I save.
