### PR TITLE
fix bugs and add link function option to pois/binom likelihood

### DIFF
--- a/R/ash.R
+++ b/R/ash.R
@@ -369,9 +369,10 @@ ash.workhorse <-
     }
     
     # constrain g within grange
-    gconstrain = constrain_mix(g, prior, grange, mixcompdist)
+    gconstrain = constrain_mix(g, pi, prior, grange, mixcompdist)
     g = gconstrain$g
     prior = gconstrain$prior
+    pi = gconstrain$pi
     
     if(mixcompdist=="halfnormal"){
       if(min(mixsd)>0){
@@ -693,7 +694,7 @@ autoselect.mixsd = function(data,mult,mode,grange,mixcompdist){
 # g: unimix or normalmix prior
 # prior: k vector
 # grange: two dimension numeric vector indicating the left and right limit of the prior g
-constrain_mix = function(g, prior, grange, mixcompdist){
+constrain_mix = function(g, pi, prior, grange, mixcompdist){
   if(mixcompdist == "normal") {
     # normal mixture prior always lies on (-Inf, Inf), so ignore grange specifications
     if (max(grange)<Inf | min(grange)>-Inf){
@@ -713,7 +714,7 @@ constrain_mix = function(g, prior, grange, mixcompdist){
     # also keep the corresponding mixture components for prior
     prior = prior[compidx]
   }
-  return(list(g=g, prior=prior))
+  return(list(g=g, prior=prior, pi=pi))
 }
 
 

--- a/R/ash.R
+++ b/R/ash.R
@@ -244,10 +244,18 @@ ash.workhorse <-
       df <- NULL
     }
   }
+  
+  # set likelihood based on defaults if missing
+  if(is.null(lik)){ 
+    if(is.null(df)){
+      lik = normal_lik()
+    } else {lik = t_lik(df)}
+  }
+  
   # poisson likelihood has non-negative g
   # do not put big weight on null component
   # automatically estimate the mode if not specified
-  if(sum(lik$name=="pois")){
+  if(lik$name=="pois"){
     if (lik$data$link=="identity"){
       grange = c(max(0,min(grange)), max(grange))
     }
@@ -255,7 +263,7 @@ ash.workhorse <-
     if(missing(mode) & missing(g)){mode = "estimate"}
   }
   # binomial likelihood (identity link) has g restricted on [0,1]
-  if(sum(lik$name=="binom")){
+  if(lik$name=="binom"){
     if (lik$data$link=="identity"){
       grange = c(max(0,min(grange)), min(1,max(grange)))
     }
@@ -272,7 +280,7 @@ ash.workhorse <-
     mode = ifelse(is.numeric(mode),mode,NA)
     
     # set range to search the mode
-    if (sum(lik$name=="pois")){
+    if (lik$name=="pois"){
       if (lik$data$link=="identity"){
         args$modemin = min(mode, min(lik$data$y),na.rm = TRUE)
         args$modemax = max(mode, max(lik$data$y),na.rm = TRUE)
@@ -280,7 +288,7 @@ ash.workhorse <-
         args$modemin = min(log(lik$data$y+0.01))
         args$modemax = max(log(lik$data$y+0.01))
       }
-    }else if(sum(lik$name=="binom")){
+    }else if(lik$name=="binom"){
       if (lik$data$link=="identity"){
         args$modemin = min(grange)
         args$modemax = max(grange)
@@ -305,11 +313,6 @@ ash.workhorse <-
   # Set optimization method
   optmethod = set_optmethod(optmethod)
   check_args(mixcompdist,df,prior,optmethod,gridmult,sebetahat,betahat)
-  if(is.null(lik)){ #set likelihood based on defaults if missing
-    if(is.null(df)){
-      lik = normal_lik()
-    } else {lik = t_lik(df)}
-  }
   check_lik(lik, betahat, sebetahat, df, mixcompdist) # minimal check that it obeys requirements
   lik = add_etruncFUN(lik) #if missing, add a function to compute mean of truncated distribution
   data = set_data(betahat, sebetahat, lik, alpha)

--- a/R/lik.R
+++ b/R/lik.R
@@ -56,26 +56,42 @@ logF_lik = function(df1,df2){
 #' @title Likelihood object for Poisson error distribution
 #' @description Creates a likelihood object for ash for use with Poisson error distribution
 #' @param y Poisson observations
+#' @param link Link function. The "identity" link directly puts unimodal prior on Poisson
+#'  intensities lambda, and "log" link puts unimodal prior on log(lambda).
 #' 
 #' @examples 
 #'    beta = c(rnorm(100,50,5)) # prior mode: 50
 #'    x = rpois(100,beta) # simulate Poisson observations
 #'    ash(rep(0,length(x)),1,lik=pois_lik(x))
 #' @export
-pois_lik = function(y){
-  list(name = "pois",
-       const = TRUE,
-       lcdfFUN = function(x){pgamma(abs(x),shape=y+1,rate=1,log.p=TRUE)},
-       lpdfFUN = function(x){dgamma(abs(x),shape=y+1,rate=1,log=TRUE)},
-       etruncFUN = function(a,b){-my_etruncgamma(-b,-a,y+1,1)},
-       e2truncFUN = function(a,b){my_e2truncgamma(-b,-a,y+1,1)},
-       data=y)
+pois_lik = function(y, link=c("identity","log")){
+  link = match.arg(link)
+  if (link=="identity"){
+    list(name = "pois",
+         const = TRUE,
+         lcdfFUN = function(x){pgamma(abs(x),shape=y+1,rate=1,log.p=TRUE)},
+         lpdfFUN = function(x){dgamma(abs(x),shape=y+1,rate=1,log=TRUE)},
+         etruncFUN = function(a,b){-my_etruncgamma(-b,-a,y+1,1)},
+         e2truncFUN = function(a,b){my_e2truncgamma(-b,-a,y+1,1)},
+         data=list(y=y,link=link))
+  }else if (link=="log"){
+    y1 = y+1e-5 # add pseudocount
+    list(name = "pois",
+         const = TRUE,
+         lcdfFUN = function(x){pgamma(exp(-x),shape=y1,rate=1,log.p=TRUE)-log(y1)},
+         lpdfFUN = function(x){dgamma(exp(-x),shape=y1,rate=1,log=TRUE)-log(y1)},
+         etruncFUN = function(a,b){-my_etruncgamma(exp(-b),exp(-a),y1,1)},
+         e2truncFUN = function(a,b){my_e2truncgamma(exp(-b),exp(-a),y1,1)},
+         data=list(y=y,link=link))
+  }
 }
 
 #' @title Likelihood object for Binomial error distribution
 #' @description Creates a likelihood object for ash for use with Binomial error distribution
 #' @param y Binomial observations
 #' @param n Binomial number of trials
+#' @param link Link function. The "identity" link directly puts unimodal prior on Binomial success
+#'  probabilities p, and "logit" link puts unimodal prior on logit(p).
 #' 
 #' @examples 
 #'    p = rbeta(100,2,2) # prior mode: 0.5
@@ -83,15 +99,29 @@ pois_lik = function(y){
 #'    y = rbinom(100,n,p) # simulate Binomial observations
 #'    ash(rep(0,length(y)),1,lik=binom_lik(y,n))
 #' @export
-binom_lik = function(y,n){
-  list(name = "binom",
-       const = TRUE,
-       lcdfFUN = function(x){pbeta(abs(x),shape1=y+1,shape2=n-y+1,log.p=TRUE)-log(n+1)},
-       lpdfFUN = function(x){dbeta(abs(x),shape1=y+1,shape2=n-y+1,log=TRUE)-log(n+1)},
-       etruncFUN = function(a,b){-my_etruncbeta(-b,-a,y+1,n-y+1)},
-       e2truncFUN = function(a,b){my_e2truncbeta(-b,-a,y+1,n-y+1)},
-       data=list(y=y,n=n))
+binom_lik = function(y,n,link=c("identity","logit")){
+  link = match.arg(link)
+  if (link=="identity"){
+    list(name = "binom",
+         const = TRUE,
+         lcdfFUN = function(x){pbeta(abs(x),shape1=y+1,shape2=n-y+1,log.p=TRUE)-log(n+1)},
+         lpdfFUN = function(x){dbeta(abs(x),shape1=y+1,shape2=n-y+1,log=TRUE)-log(n+1)},
+         etruncFUN = function(a,b){-my_etruncbeta(-b,-a,y+1,n-y+1)},
+         e2truncFUN = function(a,b){my_e2truncbeta(-b,-a,y+1,n-y+1)},
+         data=list(y=y,n=n,link=link))
+  }else if(link=="logit"){
+    y1 = y+1e-5 # add pseudocount
+    n1 = n+2e-5
+    list(name = "binom",
+         const = TRUE,
+         lcdfFUN = function(x){pbeta(1/(1+exp(-x)),shape1=y1,shape2=n1-y1,log.p=TRUE)+log(n1/(y1*(n1-y1)))},
+         lpdfFUN = function(x){dbeta(1/(1+exp(-x)),shape1=y1,shape2=n1-y1,log=TRUE)+log(n1/(y1*(n1-y1)))},
+         etruncFUN = function(a,b){-my_etruncbeta(-1/(1+exp(-b)),-1/(1+exp(-a)),y1,n1-y1)},
+         e2truncFUN = function(a,b){my_e2truncbeta(-1/(1+exp(-b)),-1/(1+exp(-a)),y1,n1-y1)},
+         data=list(y=y,n=n,link=link))
+  }
 }
+
 
 #' @title Likelihood object for normal mixture error distribution
 #' @description Creates a likelihood object for ash for use with normal mixture error distribution

--- a/R/lik.R
+++ b/R/lik.R
@@ -137,6 +137,10 @@ binom_lik = function(y,n,link=c("identity","logit")){
 
 #' @title Likelihood object for normal mixture error distribution
 #' @description Creates a likelihood object for ash for use with normal mixture error distribution
+#' @param pilik a k vector of mixture proportions (k is the number of mixture components), 
+#'    or an n*k matrix that the j'th row the is mixture proportions for betahat_j
+#' @param sdlik a k vector of component-wise standard deviations, 
+#'    or an n*k matrix that the j'th row the is component-wise standard deviations for betahat_j
 #' 
 #' @examples 
 #'    e = rnorm(100,0,0.8) 

--- a/R/lik.R
+++ b/R/lik.R
@@ -55,39 +55,51 @@ logF_lik = function(df1,df2){
 
 #' @title Likelihood object for Poisson error distribution
 #' @description Creates a likelihood object for ash for use with Poisson error distribution
-#' @param y Poisson observations
+#' @details Suppose we have Poisson observations \code{y} where \eqn{y_i\sim Poisson(c_i\lambda_i)}. 
+#'    We either put an unimodal prior g on the (scaled) intensities \eqn{\lambda_i\sim g} 
+#'    (by specifying \code{link="identity"}) or on the log intensities 
+#'    \eqn{logit(\lambda_i)\sim g} (by specifying \code{link="log"}). Either way, 
+#'    ASH with this Poisson likelihood function will compute the posterior mean of the 
+#'    intensities \eqn{\lambda_i}.
+#' @param y Poisson observations.
+#' @param scale Scale factor for Poisson observations: y~Pois(scale*lambda).
 #' @param link Link function. The "identity" link directly puts unimodal prior on Poisson
 #'  intensities lambda, and "log" link puts unimodal prior on log(lambda).
 #' 
 #' @examples 
 #'    beta = c(rnorm(100,50,5)) # prior mode: 50
-#'    x = rpois(100,beta) # simulate Poisson observations
-#'    ash(rep(0,length(x)),1,lik=pois_lik(x))
+#'    y = rpois(100,beta) # simulate Poisson observations
+#'    ash(rep(0,length(y)),1,lik=pois_lik(y))
 #' @export
-pois_lik = function(y, link=c("identity","log")){
+pois_lik = function(y, scale=1, link=c("identity","log")){
   link = match.arg(link)
   if (link=="identity"){
     list(name = "pois",
          const = TRUE,
-         lcdfFUN = function(x){pgamma(abs(x),shape=y+1,rate=1,log.p=TRUE)},
-         lpdfFUN = function(x){dgamma(abs(x),shape=y+1,rate=1,log=TRUE)},
-         etruncFUN = function(a,b){-my_etruncgamma(-b,-a,y+1,1)},
-         e2truncFUN = function(a,b){my_e2truncgamma(-b,-a,y+1,1)},
+         lcdfFUN = function(x){pgamma(abs(x),shape=y+1,rate=scale,log.p=TRUE)+y*log(scale)},
+         lpdfFUN = function(x){dgamma(abs(x),shape=y+1,rate=scale,log=TRUE)+y*log(scale)},
+         etruncFUN = function(a,b){-my_etruncgamma(-b,-a,y+1,scale)},
+         e2truncFUN = function(a,b){my_e2truncgamma(-b,-a,y+1,scale)},
          data=list(y=y,link=link))
   }else if (link=="log"){
     y1 = y+1e-5 # add pseudocount
     list(name = "pois",
          const = TRUE,
-         lcdfFUN = function(x){pgamma(exp(-x),shape=y1,rate=1,log.p=TRUE)-log(y1)},
-         lpdfFUN = function(x){dgamma(exp(-x),shape=y1,rate=1,log=TRUE)-log(y1)},
-         etruncFUN = function(a,b){-my_etruncgamma(exp(-b),exp(-a),y1,1)},
-         e2truncFUN = function(a,b){my_e2truncgamma(exp(-b),exp(-a),y1,1)},
+         lcdfFUN = function(x){pgamma(exp(-x),shape=y1,rate=scale,log.p=TRUE)-log(y1)+y*log(scale)},
+         lpdfFUN = function(x){dgamma(exp(-x),shape=y1,rate=scale,log=TRUE)-log(y1)+y*log(scale)},
+         etruncFUN = function(a,b){-my_etruncgamma(exp(-b),exp(-a),y1,scale)},
+         e2truncFUN = function(a,b){my_e2truncgamma(exp(-b),exp(-a),y1,scale)},
          data=list(y=y,link=link))
   }
 }
 
 #' @title Likelihood object for Binomial error distribution
 #' @description Creates a likelihood object for ash for use with Binomial error distribution
+#' @details Suppose we have Binomial observations \code{y} where \eqn{y_i\sim Bin(n_i,\p_i)}. 
+#'    We either put an unimodal prior g on the success probabilities \eqn{p_i\sim g} (by specifying 
+#'    \code{link="identity"}) or on the logit success probabilities \eqn{logit(p_i)\sim g} 
+#'    (by specifying \code{link="logit"}). Either way, ASH with this Binomial likelihood function 
+#'    will compute the posterior mean of the success probabilities \eqn{p_i}.
 #' @param y Binomial observations
 #' @param n Binomial number of trials
 #' @param link Link function. The "identity" link directly puts unimodal prior on Binomial success

--- a/R/process_args.R
+++ b/R/process_args.R
@@ -20,9 +20,23 @@ set_optmethod = function(optmethod){
 }
 
 
-check_lik = function(lik){
+check_lik = function(lik, betahat, sebetahat, df, mixcompdist){
   if(is.null(lik$lcdfFUN)){stop("Likelihood must have lcdfFUN")}
   if(is.null(lik$lpdfFUN)){stop("Likelihood must have lpdfFUN")}
+  
+  if(!(lik$name %in% c("normal","t")) & !is.null(df)){
+    warning("Input df is ignored for this likelihood function")
+  }
+  if(!(lik$name %in% c("normal","normalmix")) & mixcompdist == "normal"){
+    stop("Error: Normal mixture for non-normal likelihood is not yet implemented")
+  }
+  if(lik$name %in% c("pois","binom")){
+    if (!sum(betahat==0) | !sum(sebetahat==1)){
+      stop("Error: betahat must be rep(0,n) and sebetaht must be 1 for 
+           Poisson/Binomial likelihood")
+    }
+  }
+  
 }
 
 

--- a/R/truncbeta.R
+++ b/R/truncbeta.R
@@ -8,6 +8,10 @@ my_etruncbeta = function(a, b, alpha, beta){
   tmp = a
   tmp[a!=b] = (alpha/(alpha+beta)*(pbeta(b,alpha+1,beta)-pbeta(a,alpha+1,beta))/
                  (pbeta(b,alpha,beta)-pbeta(a,alpha,beta)))[a!=b]
+  # zero denominator case: pbeta(b,alpha,beta) and pbeta(a,alpha,beta) are both 0 or 1 
+  tmp[(pbeta(b,alpha,beta)-pbeta(a,alpha,beta))==0] = 
+    ifelse(dbeta(a,alpha,beta,log=TRUE)>dbeta(b,alpha,beta,log=TRUE), 
+           a, b)[(pbeta(b,alpha,beta)-pbeta(a,alpha,beta))==0]
   return(tmp)
 }
 
@@ -22,5 +26,9 @@ my_e2truncbeta = function(a, b, alpha, beta){
   tmp[a!=b] = (alpha*(alpha+1)/((alpha+beta)*(alpha+beta+1))*
                  (pbeta(b,alpha+2,beta)-pbeta(a,alpha+2,beta))/
                  (pbeta(b,alpha,beta)-pbeta(a,alpha,beta)))[a!=b]
+  # zero denominator case: pbeta(b,alpha,beta) and pbeta(a,alpha,beta) are both 0 or 1 
+  tmp[(pbeta(b,alpha,beta)-pbeta(a,alpha,beta))==0] = 
+    ifelse(dbeta(a,alpha,beta,log=TRUE)>dbeta(b,alpha,beta,log=TRUE), 
+           a^2, b^2)[(pbeta(b,alpha,beta)-pbeta(a,alpha,beta))==0]
   return(tmp)
 }

--- a/R/truncgamma.R
+++ b/R/truncgamma.R
@@ -9,6 +9,10 @@ my_etruncgamma = function(a, b, shape, rate){
   tmp = a
   tmp[a!=b] = (shape/rate*(pgamma(b,shape=shape+1,rate=rate)-pgamma(a,shape=shape+1,rate=rate))/
                  (pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate)))[a!=b]
+  # zero denominator case: pgamma(b,shape,rate) and pgamma(a,shape,rate) are both 0 or 1 
+  tmp[(pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate))==0] = 
+    ifelse(dgamma(a,shape=shape,rate=rate,log=TRUE)>dgamma(b,shape=shape,rate=rate,log=TRUE), 
+           a, b)[(pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate))==0]
   return(tmp)
 }
 
@@ -23,5 +27,9 @@ my_e2truncgamma = function(a, b, shape, rate){
   tmp = a^2
   tmp[a!=b] = (shape*(shape+1)/rate^2*(pgamma(b,shape=shape+2,rate=rate)-pgamma(a,shape=shape+2,rate=rate))/
                  (pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate)))[a!=b]
+  # zero denominator case: pgamma(b,shape,rate) and pgamma(a,shape,rate) are both 0 or 1 
+  tmp[(pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate))==0] = 
+    ifelse(dgamma(a,shape=shape,rate=rate,log=TRUE)>dgamma(b,shape=shape,rate=rate,log=TRUE), 
+           a^2, b^2)[(pgamma(b,shape=shape,rate=rate)-pgamma(a,shape=shape,rate=rate))==0]
   return(tmp)
 }

--- a/man/binom_lik.Rd
+++ b/man/binom_lik.Rd
@@ -4,12 +4,15 @@
 \alias{binom_lik}
 \title{Likelihood object for Binomial error distribution}
 \usage{
-binom_lik(y, n)
+binom_lik(y, n, link = c("identity", "logit"))
 }
 \arguments{
 \item{y}{Binomial observations}
 
 \item{n}{Binomial number of trials}
+
+\item{link}{Link function. The "identity" link directly puts unimodal prior on Binomial success
+probabilities p, and "logit" link puts unimodal prior on logit(p).}
 }
 \description{
 Creates a likelihood object for ash for use with Binomial error distribution

--- a/man/binom_lik.Rd
+++ b/man/binom_lik.Rd
@@ -17,6 +17,13 @@ probabilities p, and "logit" link puts unimodal prior on logit(p).}
 \description{
 Creates a likelihood object for ash for use with Binomial error distribution
 }
+\details{
+Suppose we have Binomial observations \code{y} where \eqn{y_i\sim Bin(n_i,\p_i)}. 
+   We either put an unimodal prior g on the success probabilities \eqn{p_i\sim g} (by specifying 
+   \code{link="identity"}) or on the logit success probabilities \eqn{logit(p_i)\sim g} 
+   (by specifying \code{link="logit"}). Either way, ASH with this Binomial likelihood function 
+   will compute the posterior mean of the success probabilities \eqn{p_i}.
+}
 \examples{
    p = rbeta(100,2,2) # prior mode: 0.5
    n = rpois(100,10)

--- a/man/normalmix_lik.Rd
+++ b/man/normalmix_lik.Rd
@@ -6,6 +6,13 @@
 \usage{
 normalmix_lik(pilik, sdlik)
 }
+\arguments{
+\item{pilik}{a k vector of mixture proportions (k is the number of mixture components), 
+or an n*k matrix that the j'th row the is mixture proportions for betahat_j}
+
+\item{sdlik}{a k vector of component-wise standard deviations, 
+or an n*k matrix that the j'th row the is component-wise standard deviations for betahat_j}
+}
 \description{
 Creates a likelihood object for ash for use with normal mixture error distribution
 }

--- a/man/pois_lik.Rd
+++ b/man/pois_lik.Rd
@@ -15,9 +15,16 @@ intensities lambda, and "log" link puts unimodal prior on log(lambda).}
 \description{
 Creates a likelihood object for ash for use with Poisson error distribution
 }
+\details{
+Suppose we have Poisson observations \code{y} where \eqn{y_i\sim Poisson(\p_i)}. 
+   We either put an unimodal prior on the intensities \eqn{p_i\sim g} (by specifying 
+   \code{link="identity"}) or on the logit intensities \eqn{logit(p_i)\sim g} (by specifying
+   \code{link="logit"}). Either way, ASH with this Poisson likelihood function will compute 
+   the posterior mean of the intensities \eqn{p_i}.
+}
 \examples{
    beta = c(rnorm(100,50,5)) # prior mode: 50
-   x = rpois(100,beta) # simulate Poisson observations
-   ash(rep(0,length(x)),1,lik=pois_lik(x))
+   y = rpois(100,beta) # simulate Poisson observations
+   ash(rep(0,length(y)),1,lik=pois_lik(y))
 }
 

--- a/man/pois_lik.Rd
+++ b/man/pois_lik.Rd
@@ -4,10 +4,12 @@
 \alias{pois_lik}
 \title{Likelihood object for Poisson error distribution}
 \usage{
-pois_lik(y, link = c("identity", "log"))
+pois_lik(y, scale = 1, link = c("identity", "log"))
 }
 \arguments{
-\item{y}{Poisson observations}
+\item{y}{Poisson observations.}
+
+\item{scale}{Scale factor for Poisson observations: y~Pois(scale*lambda).}
 
 \item{link}{Link function. The "identity" link directly puts unimodal prior on Poisson
 intensities lambda, and "log" link puts unimodal prior on log(lambda).}
@@ -16,11 +18,12 @@ intensities lambda, and "log" link puts unimodal prior on log(lambda).}
 Creates a likelihood object for ash for use with Poisson error distribution
 }
 \details{
-Suppose we have Poisson observations \code{y} where \eqn{y_i\sim Poisson(\p_i)}. 
-   We either put an unimodal prior on the intensities \eqn{p_i\sim g} (by specifying 
-   \code{link="identity"}) or on the logit intensities \eqn{logit(p_i)\sim g} (by specifying
-   \code{link="logit"}). Either way, ASH with this Poisson likelihood function will compute 
-   the posterior mean of the intensities \eqn{p_i}.
+Suppose we have Poisson observations \code{y} where \eqn{y_i\sim Poisson(c_i\lambda_i)}. 
+   We either put an unimodal prior g on the (scaled) intensities \eqn{\lambda_i\sim g} 
+   (by specifying \code{link="identity"}) or on the log intensities 
+   \eqn{logit(\lambda_i)\sim g} (by specifying \code{link="log"}). Either way, 
+   ASH with this Poisson likelihood function will compute the posterior mean of the 
+   intensities \eqn{\lambda_i}.
 }
 \examples{
    beta = c(rnorm(100,50,5)) # prior mode: 50

--- a/man/pois_lik.Rd
+++ b/man/pois_lik.Rd
@@ -4,10 +4,13 @@
 \alias{pois_lik}
 \title{Likelihood object for Poisson error distribution}
 \usage{
-pois_lik(y)
+pois_lik(y, link = c("identity", "log"))
 }
 \arguments{
 \item{y}{Poisson observations}
+
+\item{link}{Link function. The "identity" link directly puts unimodal prior on Poisson
+intensities lambda, and "log" link puts unimodal prior on log(lambda).}
 }
 \description{
 Creates a likelihood object for ash for use with Poisson error distribution

--- a/tests/testthat/test_binom.R
+++ b/tests/testthat/test_binom.R
@@ -72,7 +72,7 @@ test_that("binom_lik (logit link) fitted g is close to true g",{
   p = 1/(1+exp(-logitp))
   n = rep(100,1000)
   x = rbinom(1000,n,p) # Binomial observations
-  ash.binom.out = ash(rep(0,length(x)),1,lik=binom_lik1(x,n,link="logit"),mode="estimate")
+  ash.binom.out = ash(rep(0,length(x)),1,lik=binom_lik(x,n,link="logit"),mode="estimate")
   
   # Check if the estimated mode is close to the true mode
   expect_equal(ash.binom.out$fitted_g$a[1], truemode, tolerance = 0.05, scale=x)

--- a/tests/testthat/test_binom.R
+++ b/tests/testthat/test_binom.R
@@ -1,4 +1,4 @@
-test_that("binom_lik fitted g is close to true g",{
+test_that("binom_lik (identity link) fitted g is close to true g",{
   # Simulate a Binomial dataset
   set.seed(1)
   trueg = unimix(c(0.5,0.5),c(0.5,0.1),c(0.5,0.9)) # true prior g: 0.5*U(0.1,0.9)+0.5*delta(0.5)
@@ -12,7 +12,7 @@ test_that("binom_lik fitted g is close to true g",{
   expect_equal(ash.binom.out$fitted_g$pi, c(0.5,0.5), tolerance = 0.05)
 })
 
-test_that("binom_lik fitted g is close to true g",{
+test_that("binom_lik (identity link) fitted g is close to true g",{
   # Simulate a Binomial dataset
   set.seed(1)
   truemode = 0.3
@@ -22,12 +22,11 @@ test_that("binom_lik fitted g is close to true g",{
   x = rbinom(1000,n,p) # Binomial observations
   ash.binom.out = ash(rep(0,length(x)),1,lik=binom_lik(x,n),mode="estimate")
   
-  # Check if the estimated mixture proportion for components delta(0.5) and U(0.1,0.9)
-  # is close to the true mixture proportion (0.5,0.5)
+  # Check if the estimated mode is close to the true mode 0.3
   expect_equal(ash.binom.out$fitted_g$a[1], truemode, tolerance = 0.05, scale=x)
 })
 
-test_that("binom_lik with big n gives similar answers to normal likelihood",{
+test_that("binom_lik (identity link) with big n gives similar answers to normal likelihood",{
   # Simulate a Binomial data set with n=200
   set.seed(1)
   p = c(rep(0.3,500), runif(500,0.1,0.5)) # generate p
@@ -47,4 +46,34 @@ test_that("binom_lik with big n gives similar answers to normal likelihood",{
   expect_equal(ash.norm.out$result$PosteriorMean,
                ash.binom.out$result$PosteriorMean,
                tolerance = 0.05, scale=x)
+})
+
+test_that("binom_lik (logit link) fitted g is close to true g",{
+  # Simulate a Binomial dataset
+  set.seed(1)
+  trueg = unimix(c(0.5,0.5),c(0,-3),c(0,3)) 
+  logitp = c(rep(0,500), runif(500,-3,3))
+  p = 1/(1+exp(-logitp))
+  n = rep(1000,1000)
+  x = rbinom(1000,n,p) # Binomial observations
+  ash.binom.out = ash(rep(0,length(x)),1,lik=binom_lik(x,n,link="logit"),
+                      g=trueg,prior="uniform")
+  
+  # Check if the estimated mixture proportion for components delta(0.5) and U(-3,3)
+  # is close to the true mixture proportion (0.5,0.5)
+  expect_equal(ash.binom.out$fitted_g$pi, c(0.5,0.5), tolerance = 0.05)
+})
+
+test_that("binom_lik (logit link) fitted g is close to true g",{
+  # Simulate a Binomial dataset
+  set.seed(1)
+  truemode = 0
+  logitp = c(rep(0,800), runif(200,-3,3))
+  p = 1/(1+exp(-logitp))
+  n = rep(100,1000)
+  x = rbinom(1000,n,p) # Binomial observations
+  ash.binom.out = ash(rep(0,length(x)),1,lik=binom_lik1(x,n,link="logit"),mode="estimate")
+  
+  # Check if the estimated mode is close to the true mode
+  expect_equal(ash.binom.out$fitted_g$a[1], truemode, tolerance = 0.05, scale=x)
 })

--- a/tests/testthat/test_pois.R
+++ b/tests/testthat/test_pois.R
@@ -1,4 +1,4 @@
-test_that("pois_lik fitted g is close to true g",{
+test_that("pois_lik (identity link) fitted g is close to true g",{
   # Simulate a Poisson dataset
   set.seed(1)
   trueg = unimix(c(0.5,0.5),c(1,1),c(1,5)) # true prior g: 0.5*U(1,5)+0.5*delta(1)
@@ -11,7 +11,7 @@ test_that("pois_lik fitted g is close to true g",{
   expect_equal(ash.pois.out$fitted_g$pi, c(0.5,0.5), tolerance = 0.05)
 })
 
-test_that("pois_lik fitted mode is close to true mode",{
+test_that("pois_lik (identity link) fitted mode is close to true mode",{
   # Simulate a Poisson dataset
   set.seed(1)
   truemode = 50 # set mode of prior g
@@ -23,7 +23,7 @@ test_that("pois_lik fitted mode is close to true mode",{
   expect_equal(ash.pois.out$fitted_g$a[1], truemode, tolerance = 0.05, scale=x)
 })
 
-test_that("pois_lik with high intensities gives similar answers to normal likelihood",{
+test_that("pois_lik (identity link) with high intensities gives similar answers to normal likelihood",{
   # Simulate a Poisson data set with relatively high intensities
   set.seed(1)
   lambda = c(rnorm(1000,200,5)) # simulate intensities around 200
@@ -42,4 +42,31 @@ test_that("pois_lik with high intensities gives similar answers to normal likeli
   expect_equal(ash.norm.out$result$PosteriorMean,
                ash.pois.out$result$PosteriorMean,
                tolerance = 0.05, scale=x)
+})
+
+test_that("pois_lik (log link) fitted g is close to true g",{
+  # Simulate a Poisson dataset
+  set.seed(1)
+  trueg = unimix(c(0.8,0.2),c(0,-3),c(0,3)) 
+  loglambda = c(rep(0,800), runif(200,-3,3)) 
+  lambda = exp(loglambda)
+  x = rpois(1000,lambda) # Poisson observations
+  ash.pois.out = ash(rep(0,length(x)),1,lik=pois_lik(x,link="log"),g=trueg)
+  
+  # Check if the estimated mixture proportion for components delta(0) and U(-3,3)
+  # is close to the true mixture proportion (0.8,0.2)
+  expect_equal(ash.pois.out$fitted_g$pi, c(0.8,0.2), tolerance = 0.05)
+})
+
+test_that("pois_lik (log link) fitted mode is close to true mode",{
+  # Simulate a Poisson dataset
+  set.seed(1)
+  truemode = 4
+  loglambda = c(rep(4,500), rnorm(500,4,1)) # simulate log(lambda) from distn w/ mode at 4
+  lambda = exp(loglambda)
+  x = rpois(1000,lambda) # Poisson observations
+  ash.pois.out = ash(rep(0,length(x)),1,lik=pois_lik(x,link="log"),mode="estimate")
+  
+  # Check if the estimated mode is close to the true mode 50
+  expect_equal(ash.pois.out$fitted_g$a[1], truemode, tolerance = 0.05, scale=x)
 })

--- a/tests/testthat/test_truncgen.R
+++ b/tests/testthat/test_truncgen.R
@@ -21,7 +21,7 @@ test_that("ash with automatic truncfun gives similar answers to default", {
   set.seed(10); z=rnorm(10,0,4);
   a1 = ash(z,1)
   
-  testlik = list(lcdfFUN = function(x){pnorm(x,log=TRUE)},
+  testlik = list(name="norm",lcdfFUN = function(x){pnorm(x,log=TRUE)},
        lpdfFUN = function(x){dnorm(x,log=TRUE)})
   a2 = ash(z,1,lik=testlik)
   expect_equal(a1$PosteriorMean,a2$PosteriorMean)


### PR DESCRIPTION
1. Fix bugs in truncgamma.R and truncbeta.R.
2. Fix bugs of the "grange" option for ash.workhorse().
3. For Poisson or Binomial likelihood mode, add "link function" options. Binomial likelihood Binom(n,p) with "logit" link puts an unimodal prior on logit(p), and Poisson likelihood Pois(lambda) with "log" link puts an unimodal prior on log(lambda).
