### PR TITLE
never drop mixture components for which prior > 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ Authors@R: c(person("Matthew","Stephens",role="aut",
              person("Jason","Willwerscheid",role="aut"),
              person("Nan","Xiao",role="aut"),
              person("Mazon","Zeng",role="ctb"))
-Version: 2.2-50
-Date: 2020-04-06
+Version: 2.2-51
+Date: 2020-07-21
 Title: Methods for Adaptive Shrinkage, using Empirical Bayes
 Description: The R package 'ashr' implements an Empirical Bayes
     approach for large-scale hypothesis testing and false discovery

--- a/R/ash.R
+++ b/R/ash.R
@@ -591,7 +591,7 @@ estimate_mixprop = function (data, g, prior,
   matrix_lik = exp(matrix_llik)
 
   # All-zero columns pose problems for most optimization methods.
-  nonzero_cols = (apply(matrix_lik, 2, max) > 0)
+  nonzero_cols = (apply(matrix_lik, 2, max) > 0) | (prior > 1)
   if (!all(nonzero_cols)) {
     prior = prior[nonzero_cols]
     weights = weights[nonzero_cols]

--- a/tests/testthat/test_prior.R
+++ b/tests/testthat/test_prior.R
@@ -19,5 +19,19 @@ test_that("numeric and (partial) string arguments both work", {
                          g = normalmix(rep(0, 5), rep(0, 5), 0:4), fixg = FALSE,
                          prior = "null")
   expect_false(identical(aout1$result$PosteriorMean, aout3$result$PosteriorMean))
-}
-)
+})
+
+test_that("pi is nonzero for mixture components where prior > 1", {
+  x <- 10:20
+  s <- rep(1, 11)
+  g <- unimix(rep(0, 3), c(0, -1, -20), c(0, 1, 20))
+  aout1 <- ash(x, s, g = g, fixg = FALSE, prior = c(1, 1, 1), mixcompdist = "uniform")
+  expect_false(all(aout1$fitted_g$pi > 0))
+  
+  aout2 <- ash(x, s, g = g, fixg = FALSE, prior = c(10, 10, 10), mixcompdist = "uniform")
+  expect_true(all(aout2$fitted_g$pi > 0))
+  
+  aout3 <- ash(x, s, g = g, fixg = FALSE, prior = c(10, 1, 10), mixcompdist = "uniform")
+  expect_true(aout3$fitted_g$pi[1] > 0)
+  expect_false(aout3$fitted_g$pi[2] > 0)
+})


### PR DESCRIPTION
We've been dropping columns from the likelihood matrix that are identically zero. This causes the corresponding mixture proportion to be estimated as zero. This is the right thing to do when the prior parameter for that mixture component is 1, but it's otherwise incorrect. I've changed to only drop when the likelihood is identically zero AND the prior parameter is 1. This works fine with `mixsqp`, but I'm not familiar enough with the other optimization methods to be confident that the change won't break anything. Would you mind taking a look @pcarbo ?