### PR TITLE
Fix post_sample indexing edge case

### DIFF
--- a/R/normalmix.R
+++ b/R/normalmix.R
@@ -167,7 +167,7 @@ post_sample.normalmix = function(m,data,nsamp){
     sample(1:k, nsamp, replace=TRUE, prob=prob)
   })
   # Use samples to index into postmean and postsd matrices
-  idx = mixcomp + rep(k*(0:(n-1)), each=nsamp)
+  idx = as.vector(mixcomp + rep(k*(0:(n-1)), each=nsamp))
   samp = rnorm(nsamp*n, postmean[idx], postsd[idx])
   matrix(samp, nrow=nsamp, ncol=n)
 }


### PR DESCRIPTION
For a data set with two samples idx is treated as a matrix rather than a vector.

"When indexing arrays by [ a single argument i can be a matrix with as many columns as there are dimensions of x; the result is then a vector with elements corresponding to the sets of indices in each row of i."