### PR TITLE
Masked density output for normal mixture

### DIFF
--- a/R/tnormalmix.R
+++ b/R/tnormalmix.R
@@ -58,7 +58,10 @@ comp_dens.tnormalmix = function (m, y, log = FALSE) {
   n = length(y)
   d = matrix(rep(y,rep(k,n)),nrow = k)
   # No cases of b = a.
-  return(matrix(dnorm(d,m$mean,m$sd))/(pnorm(m$b) - pnorm(m$a)))
+  comp_dens = dnorm(d,m$mean,m$sd)/(pnorm(m$b) - pnorm(m$a))
+  comp_dens_mask = sapply(1:k, function(comp) { as.numeric((y >= m$a[comp]) & (y <= m$b[comp])) })
+
+  return(comp_dens * t(comp_dens_mask))
 }
 
 #' @importFrom stats pnorm


### PR DESCRIPTION
# Bug Report

When I try to use the `get_density` function in the package to plot the density of a mixture of half-normal distributions, I get a (perfectly) symmetric distribution even though the input data is not symmetric around zero. The `get_density` function also cannot handle more than one input value when using the half-normal prior.

## Replication Steps

First, I simulate some data that is clearly skewed.
```
set.seed(42)
b <- c(-rnorm(100, sd=5)^2, rnorm(100, sd=1)^2)
s <- runif(200, min=0.5)
```

Next, I fit ASH using the half-normal prior.
```
ash.res <- ash(b, s, mixcompdist="halfnormal")
```

I expect the following command to work, but it throws an error.
```
get_density(ash.res, seq(-10, 10, length.out=101))
# Error!
```

The function works for individual values, but the density is the same at -3 and 3 (very unlikely based on the data).
```
get_density(ash.res, -3)
get_density(ash.res, 3)
```

If I evaluate `get_density` one-value-at-a-time using `sapply`, I get a symmetric distribution.
```
x <- seq(-10, 10, length.out=101)
y <- sapply(x, function(i) { get_density(ash.res, i)$y })
plot(x, y, type="l")
```
![plot_1](https://github.com/user-attachments/assets/f6a8e7e1-e26c-4ccd-a76e-83e928ae4983)

# Proposed Fix

I believe the issue lies in the `comp_dens.tnormalmix` function in `R/tnormalmix.R` file. Previously, this function returned a matrix of density values for each component (the matrix is component by target values). However, the output is not masked by the support of the mixture components. I add this masking in the fix.

## Concerns

I'm not sure if this is the right place to implement the masking.

## Replicating the Fix

First, generate the skewed data and fit the model.
```
set.seed(42)
b <- c(-rnorm(100, sd=5)^2, rnorm(100, sd=1)^2)
s <- runif(200, min=0.5)

ash.res <- ash(b, s, mixcompdist="halfnormal")
```

Now, `get_density` works properly with vector-valued targets.
```
get_density(ash.res, seq(-10, 10, length.out=101))
```

Furthermore, the density looks non-symmetric around zero.
```
density <- get_density(ash.res, seq(-10, 10, length.out=101))
plot(density$x, density$y, type="l")
```
![plot_2](https://github.com/user-attachments/assets/aa39265c-bbb0-45ba-8a64-df6e3fbef966)