### PR TITLE
Stable log(1 - exp(.)) in log_comp_dens_conv.unimix

### DIFF
--- a/R/unimix.R
+++ b/R/unimix.R
@@ -1,5 +1,25 @@
 
 
+# Stable computation of log(1 - exp(z)) for z <= 0.
+# Uses log1p(-exp(z)) when z < -log(2), and log(-expm1(z)) otherwise.
+# This keeps precision when z is close to 0, where the naive form
+# log(1 - exp(z)) underflows to log(0) = -Inf because exp(z) rounds
+# to 1. Used in log_comp_dens_conv.unimix where z = lpb - lpa can
+# be very close to 0 (narrow uniform component, or two log-CDF
+# values nearly equal in the tail).
+# Reference: Maechler (2012), "Accurately Computing log(1 - exp(-|a|))",
+# https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+log1mexp = function(z) {
+  # Default branch handles every value, including NaN / NA (which
+  # propagate naturally through expm1 and log). We deliberately avoid
+  # ifelse() because comparisons on NaN evaluate to NA, which would
+  # turn NaN inputs into NA outputs.
+  out = log(-expm1(z))
+  small = !is.na(z) & z < -log(2)
+  out[small] = log1p(-exp(z[small]))
+  out
+}
+
 ############################### METHODS FOR unimix class ###########################
 
 #' @title Constructor for unimix class
@@ -74,7 +94,7 @@ log_comp_dens_conv.unimix = function(m,data){
     lpb = tmp
   }
    
-  lcomp_dens = t(lpa + log(1-exp(lpb-lpa))) - log(b-a)
+  lcomp_dens = t(lpa + log1mexp(lpb-lpa)) - log(b-a)
   lcomp_dens[a==b,] = t(do.call(lik$lpdfFUN, list(outer(data$x,b,FUN="-")/data$s))
                        -log(data$s))[a==b,]
   return(lcomp_dens)

--- a/tests/testthat/test_log_comp_dens.R
+++ b/tests/testthat/test_log_comp_dens.R
@@ -35,3 +35,42 @@ test_that("comp_postprob is numerically stable", {
   expect_equal(comp_postprob(g,set_data(-10,0.5)),cbind(c(2/3,1/3)))
   expect_equal(comp_postprob(g,set_data(-20,0.5)),cbind(c(2/3,1/3)))
 })
+
+test_that("log1mexp matches log(1 - exp(z)) on safe range and stays finite near 0", {
+  # On the safe range, log1mexp should match the naive log(1 - exp(z))
+  # to machine precision.
+  z = c(-10, -5, -2, -1, -log(2), -0.5, -0.1, -1e-3, -1e-6, -1e-9)
+  expect_equal(ashr:::log1mexp(z), log(1 - exp(z)))
+
+  # When |z| is below ~1e-16, the naive form returns -Inf because exp(z)
+  # rounds to 1. log1mexp should stay finite and close to log(|z|).
+  z_small = c(-1e-17, -1e-18, -1e-20)
+  out = ashr:::log1mexp(z_small)
+  expect_true(all(is.finite(out)))
+  expect_equal(out, log(-z_small), tolerance = 1e-12)
+
+  # NaN / NA inputs must propagate as NaN / NA respectively (not get
+  # silently converted to NA by an internal comparison).
+  expect_true(is.nan(ashr:::log1mexp(NaN)))
+  expect_true(is.na(ashr:::log1mexp(NA_real_)))
+})
+
+test_that("log_comp_dens_conv.unimix limit as b -> a matches normal density / s", {
+  # As (b - a) -> 0 with a normal likelihood, the convolution density
+  # approaches (1/s) * dnorm((x - a)/s). Check this in the tail, where
+  # the old log(1 - exp(.)) form loses precision.
+  # NOTE: log_comp_dens_conv.unimix is not registered as an S3 method
+  # in NAMESPACE, so we call the method directly instead of going
+  # through UseMethod dispatch.
+  x = 0
+  s = 1
+  a = 5
+  ref = dnorm(x - a, 0, s, log = TRUE) - log(s)
+  for (eps in c(1e-3, 1e-6, 1e-9)) {
+    g = unimix(1, a, a + eps)
+    data = set_data(x, s)
+    lcd = as.numeric(ashr:::log_comp_dens_conv.unimix(g, data))
+    expect_true(is.finite(lcd))
+    expect_equal(lcd, ref, tolerance = 1e-3)
+  }
+})


### PR DESCRIPTION
## Summary

In `R/unimix.R`, `log_comp_dens_conv.unimix` evaluates

    lcomp_dens = t(lpa + log(1 - exp(lpb - lpa))) - log(b - a)

where `lpa` and `lpb` are log-CDF values from the likelihood. When
`lpa` and `lpb` are very close (narrow uniform component, or both
values far in the tail), `exp(lpb - lpa)` rounds to `1` in double
precision and `log(1 - exp(.))` returns `-Inf`, even though the true
value is finite.

For example, at `z = lpb - lpa = -1e-17`:
- old form: `log(1 - exp(z))` -> `-Inf`
- correct value: `log(-z)` ~ `-39.14`

This PR replaces that step with a small private helper, `log1mexp(z)`,
which uses `log1p(-exp(z))` when `z < -log(2)` and `log(-expm1(z))`
otherwise. Both are standard ways of computing `log(1 - exp(z))` that
keep precision. See Maechler (2012), *Accurately Computing log(1 - exp(-|a|))*:
https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf

On the safe range the result matches the old form to machine
precision. In the tail regime the result is now finite where the old
form returned `-Inf`.

## Changes

- `R/unimix.R`: add private `log1mexp()` helper; use it inside
  `log_comp_dens_conv.unimix`.
- `tests/testthat/test_log_comp_dens.R`: add two `test_that` blocks
  covering (a) `log1mexp` precision and `NaN`/`NA` propagation and
  (b) the narrow-uniform limit `b -> a` matching `(1/s) * dnorm((x - a)/s)`.

No public API changes. No new dependencies.

## Follow-ups (out of scope for this PR)

A near-identical pattern exists in `R/truncnorm.R::logscale_sub`,
which computes `log(exp(logx) - exp(logy))` via a manual `scale.by`
trick equivalent to `logx + log(1 - exp(logy - logx))`. Once
`log1mexp` lands here it can be reused there to remove the manual
scaling and gain the same precision.