### PR TITLE
Reuse log1mexp() in logscale_sub

### DIFF
--- a/R/truncnorm.R
+++ b/R/truncnorm.R
@@ -239,8 +239,12 @@ do_truncnorm_argchecks = function(a, b) {
 }
 
 logscale_sub = function(logx, logy) {
-  # In rare cases, logx can become numerically less than logy. When this
-  #   occurs, logx is adjusted and a warning is issued.
+  # Stable computation of log(exp(logx) - exp(logy)) for logx >= logy.
+  # Equivalent to logx + log(1 - exp(logy - logx)); we use log1mexp
+  # (defined in R/unimix.R) on the inner term to avoid underflow when
+  # logy is very close to logx.
+  # In rare cases, logx can become numerically less than logy. When
+  # this occurs, logx is adjusted and a warning is issued.
   diff = logx - logy
   if (any(diff < 0, na.rm = TRUE)) {
     bad.idx = (diff < 0)
@@ -249,8 +253,12 @@ logscale_sub = function(logx, logy) {
     warning("logscale_sub encountered negative value(s) of logx - logy (min: ",
             formatC(min(diff[bad.idx]), format = "e", digits = 2), ")")
   }
-  
-  scale.by = logx
-  scale.by[is.infinite(scale.by)] = 0
-  return(log(exp(logx - scale.by) - exp(logy - scale.by)) + scale.by)
+
+  out = logx + log1mexp(logy - logx)
+  # Handle the both-equal-(-Inf) case: exp(-Inf) - exp(-Inf) = 0, so
+  # the answer is log(0) = -Inf. The expression above gives NaN here
+  # because (-Inf) - (-Inf) = NaN propagates through log1mexp.
+  both_neg_inf = is.infinite(logx) & is.infinite(logy) & logx < 0 & logy < 0
+  out[both_neg_inf] = -Inf
+  return(out)
 }

--- a/tests/testthat/test_log_comp_dens.R
+++ b/tests/testthat/test_log_comp_dens.R
@@ -55,6 +55,34 @@ test_that("log1mexp matches log(1 - exp(z)) on safe range and stays finite near 
   expect_true(is.na(ashr:::log1mexp(NA_real_)))
 })
 
+test_that("logscale_sub matches naive log(exp - exp) on safe range and stays finite when logx ~ logy", {
+  # On the safe range (logx > logy by a comfortable margin), logscale_sub
+  # should match the naive log(exp(logx) - exp(logy)) to high precision.
+  logx = c(  0,  -5,  10, -50, -100)
+  logy = c(-1,  -7,   8, -55, -200)
+  ref  = log(exp(logx) - exp(logy))
+  expect_equal(ashr:::logscale_sub(logx, logy), ref, tolerance = 1e-12)
+
+  # When logx and logy are very close, the naive form returns -Inf
+  # because exp(logy - logx) rounds to 1. logscale_sub should stay
+  # finite and equal logx + log(logx - logy) to first order.
+  # We anchor at logx = 0 so that very small (logx - logy) values
+  # remain representable in double precision.
+  logx_close = c(0, 0, 0)
+  logy_close = c(-1e-12, -1e-15, -1e-17)
+  out = ashr:::logscale_sub(logx_close, logy_close)
+  expect_true(all(is.finite(out)))
+  expect_equal(out, logx_close + log(logx_close - logy_close), tolerance = 1e-6)
+
+  # Corner case used by my_etruncnorm with (a = -Inf, b = +Inf):
+  # dnorm(+-Inf, log = TRUE) = -Inf, so logscale_sub is called with
+  # both arguments equal to -Inf. The mathematically correct answer
+  # is log(0 - 0) = -Inf, not NaN.
+  expect_equal(ashr:::logscale_sub(-Inf, -Inf), -Inf)
+  expect_equal(ashr:::logscale_sub(c(-Inf, 0), c(-Inf, -1)),
+               c(-Inf, log(1 - exp(-1))))
+})
+
 test_that("log_comp_dens_conv.unimix limit as b -> a matches normal density / s", {
   # As (b - a) -> 0 with a normal likelihood, the convolution density
   # approaches (1/s) * dnorm((x - a)/s). Check this in the tail, where


### PR DESCRIPTION
## Summary

Follow-up to #147. `logscale_sub` (in `R/truncnorm.R`) computes
`log(exp(logx) - exp(logy))` for `logx >= logy` via a manual
`scale.by` trick that is mathematically equivalent to
`logx + log(1 - exp(logy - logx))`. It shared the same precision
issue fixed in #147: when `logy` is very close to `logx`,
`exp(logy - logx)` rounds to `1` in double precision and
`log(1 - .)` returns `-Inf` even though the true value is finite.

This PR replaces the inner `log(1 - exp(.))` with `log1mexp()`
(already in the package namespace as of #147). The manual `scale.by`
handling is no longer needed.

## Corner case handled explicitly

`my_etruncnorm` calls `logscale_sub` with both arguments equal to
`dnorm(+-Inf, log = TRUE) = -Inf` when the truncation interval is
`(-Inf, +Inf)`. The natural expression `(-Inf) - (-Inf) = NaN` would
propagate through `log1mexp`; the correct answer is `log(0 - 0) = -Inf`.
The previous implementation handled this implicitly via its `scale.by`
branch. The refactored version handles it explicitly.

## Changes

- `R/truncnorm.R`: refactor `logscale_sub` to use `log1mexp`; remove
  the manual `scale.by` scaling; add explicit handling of the
  both-equal-`(-Inf)` case.
- `tests/testthat/test_log_comp_dens.R`: add one `test_that` block
  covering the safe range, the close-to-equal regime, and the
  both-equal-`(-Inf)` corner case.

No public API changes. No new dependencies.

## Reference

Maechler, M. (2012). *Accurately Computing log(1 - exp(-|a|))*.
https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf